### PR TITLE
Improve rollout with stable tag and expand to cronjobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,7 @@ executors:
 workflows:
   main:
     jobs:
-      - test:
-          filters:
-            tags:
-              # Simplified SemVer regex
-              only: /^\d+\.\d+\.\d+$/
+      - test
       - publish:
           requires:
             - test

--- a/orb.yml
+++ b/orb.yml
@@ -317,6 +317,10 @@ jobs:
         description: A docker image tag
         type: string
         default: "latest"
+      stable-tag:
+        description: A docker image tag added after a successful image rollout
+        type: string
+        default: "$CIRCLE_BRANCH.stable"
       path-to-dockerfile:
         description: The relative path to the Dockerfile to use when building image
         type: string
@@ -353,6 +357,11 @@ jobs:
           namespace: "<<parameters.namespace>>"
           container: "<<parameters.container>>"
           image: "<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>>"
+      - gcr/push-image:
+          registry-url: <<parameters.registry-url>>
+          google-project-id: <<parameters.google-project-id>>
+          image: <<parameters.image>>
+          tag: "<<parameters.stable-tag>>"
       - notify-datadog:
           image: "<<parameters.image>>:<<parameters.tag>>"
       - notify-sentry:

--- a/orb.yml
+++ b/orb.yml
@@ -35,6 +35,7 @@ commands:
       deployment:
         description: "The Kubernetes deployment name."
         type: string
+        default: ""
       container:
         description: "The Kubernetes container name."
         type: string
@@ -48,7 +49,24 @@ commands:
     steps:
       - run: |
           gcloud container clusters get-credentials <<parameters.cluster>>
-          kubectl -n <<parameters.namespace>> set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
+          if [ "x<<parameters.deployment>>" == "x" ] ; then
+            _buildless_image=$(echo "<<parameters.image>>" | rev | cut -d. -f2- | rev)
+            echo "Detecting resources that have a image starting with: $_buildless_image"
+            for data in $(kubectl get --all-namespaces cronjob,deployment -o json | jq -c --arg img "${_buildless_image}" '.items[] | .kind as $kind | .metadata.name as $name | .metadata.namespace as $namespace | ((if .kind == "CronJob" then .spec.jobTemplate else . end) | .spec.template.spec.containers[]) | select(.image | startswith($img)) | {container: .name, name: $name, namespace: $namespace, kind: $kind}'); do
+              echo "Found resource: $data"
+              namespace=$(echo $data | jq -r .namespace)
+              name=$(echo $data | jq -r .name)
+              kind=$(echo $data | jq -r .kind)
+              container=$(echo $data | jq -r .container)
+              kubectl -n $namespace set image $kind/$name ${container}=<<parameters.image>>
+              if test "$kind" = "Deployment"; then
+                kubectl -n $namespace rollout status $kind/$name
+              fi
+            done
+          else
+            kubectl -n <<parameters.namespace>> set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
+            kubectl -n <<parameters.namespace>> rollout status deployment <<parameters.deployment>>
+          fi
   notify-datadog:
     description: Send a deploy event to DataDog
     parameters:
@@ -287,6 +305,7 @@ jobs:
       deployment:
         description: "The Kubernetes deployment name."
         type: string
+        default: ""
       namespace:
         description: "The Kubernetes namespace name."
         type: string

--- a/orb.yml
+++ b/orb.yml
@@ -384,11 +384,6 @@ jobs:
           image: <<parameters.image>>
           source-tag: <<parameters.tag>>
           target-tag: "<<parameters.stable-tag>>"
-      - gcr/push-image:
-          registry-url: <<parameters.registry-url>>
-          google-project-id: <<parameters.google-project-id>>
-          image: <<parameters.image>>
-          tag: "<<parameters.stable-tag>>"
       - notify-datadog:
           image: "<<parameters.image>>:<<parameters.tag>>"
       - notify-sentry:

--- a/orb.yml
+++ b/orb.yml
@@ -378,6 +378,12 @@ jobs:
           namespace: "<<parameters.namespace>>"
           container: "<<parameters.container>>"
           image: "<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>>"
+      - gcr/tag-image:
+          registry-url: <<parameters.registry-url>>
+          google-project-id: <<parameters.google-project-id>>
+          image: <<parameters.image>>
+          source-tag: <<parameters.tag>>
+          target-tag: "<<parameters.stable-tag>>"
       - gcr/push-image:
           registry-url: <<parameters.registry-url>>
           google-project-id: <<parameters.google-project-id>>

--- a/orb.yml
+++ b/orb.yml
@@ -17,6 +17,15 @@ commands:
     description: "Initialize the `gcloud` CLI."
     steps:
       - gcloud/initialize
+  checkout-submodule:
+    description: "checkout repo with submodules"
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update
   rollout-image:
     description: "Update a deployment's Docker image."
     parameters:
@@ -185,12 +194,7 @@ jobs:
           Extra flags to pass to docker build. For examples, see
           https://docs.docker.com/engine/reference/commandline/build
     steps:
-      - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update --remote
+      - checkout-submodule
       - attach_workspace:
           at: ./
       - gcr/gcr-auth:
@@ -251,12 +255,7 @@ jobs:
         type: string
         default: "latest"
     steps:
-      - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update --remote
+      - checkout-submodule
       - gcr/gcr-auth:
           google-project-id: <<parameters.google-project-id>>
           google-compute-zone: <<parameters.google-compute-zone>>
@@ -329,12 +328,7 @@ jobs:
           Extra flags to pass to docker build. For examples, see
           https://docs.docker.com/engine/reference/commandline/build
     steps:
-      - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update --remote
+      - checkout-submodule
       - attach_workspace:
           at: ./
       - gcr/gcr-auth:

--- a/orb.yml
+++ b/orb.yml
@@ -47,26 +47,28 @@ commands:
         type: string
         default: "default"
     steps:
-      - run: |
-          gcloud container clusters get-credentials <<parameters.cluster>>
-          if [ "x<<parameters.deployment>>" == "x" ] ; then
-            _buildless_image=$(echo "<<parameters.image>>" | rev | cut -d. -f2- | rev)
-            echo "Detecting resources that have a image starting with: $_buildless_image"
-            for data in $(kubectl get --all-namespaces cronjob,deployment -o json | jq -c --arg img "${_buildless_image}" '.items[] | .kind as $kind | .metadata.name as $name | .metadata.namespace as $namespace | ((if .kind == "CronJob" then .spec.jobTemplate else . end) | .spec.template.spec.containers[]) | select(.image | startswith($img)) | {container: .name, name: $name, namespace: $namespace, kind: $kind}'); do
-              echo "Found resource: $data"
-              namespace=$(echo $data | jq -r .namespace)
-              name=$(echo $data | jq -r .name)
-              kind=$(echo $data | jq -r .kind)
-              container=$(echo $data | jq -r .container)
-              kubectl -n $namespace set image $kind/$name ${container}=<<parameters.image>>
-              if test "$kind" = "Deployment"; then
-                kubectl -n $namespace rollout status $kind/$name
-              fi
-            done
-          else
-            kubectl -n <<parameters.namespace>> set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
-            kubectl -n <<parameters.namespace>> rollout status deployment <<parameters.deployment>>
-          fi
+      - run:
+          name: Rollout image
+          command: |
+            gcloud container clusters get-credentials <<parameters.cluster>>
+            if [ "x<<parameters.deployment>>" == "x" ] ; then
+              _buildless_image=$(echo "<<parameters.image>>" | rev | cut -d. -f2- | rev)
+              echo "Detecting resources that have a image starting with: $_buildless_image"
+              for data in $(kubectl get --all-namespaces cronjob,deployment -o json | jq -c --arg img "${_buildless_image}" '.items[] | .kind as $kind | .metadata.name as $name | .metadata.namespace as $namespace | ((if .kind == "CronJob" then .spec.jobTemplate else . end) | .spec.template.spec.containers[]) | select(.image | startswith($img)) | {container: .name, name: $name, namespace: $namespace, kind: $kind}'); do
+                echo "Found resource: $data"
+                namespace=$(echo $data | jq -r .namespace)
+                name=$(echo $data | jq -r .name)
+                kind=$(echo $data | jq -r .kind)
+                container=$(echo $data | jq -r .container)
+                kubectl -n $namespace set image $kind/$name ${container}=<<parameters.image>>
+                if test "$kind" = "Deployment"; then
+                  kubectl -n $namespace rollout status $kind/$name
+                fi
+              done
+            else
+              kubectl -n <<parameters.namespace>> set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
+              kubectl -n <<parameters.namespace>> rollout status deployment <<parameters.deployment>>
+            fi
   notify-datadog:
     description: Send a deploy event to DataDog
     parameters:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Move the orb one step closer to a universal gke deployment tool.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

This change:
1. Wait's for image rollouts to succeed
2. Tags the successfully rolled out images with a stable tag
3. Mirrors rollout logic of `tm-infrastructure/Makefile`

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
