### PR TITLE
Add vpn connecting to push deploy job when config present

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,3 +5,4 @@ orbs:
   gcloud: circleci/gcp-cli@1.0.6
   gcr: circleci/gcp-gcr@0.6.1
   k8s: circleci/kubernetes@0.1.0
+  vpn: titel-media/wireguard@0.0.5

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -2,3 +2,7 @@ description: "Install `gcloud` and `kubectl` if not already installed."
 steps:
   - gcloud/install
   - k8s/install
+  - when:
+      condition: $WIREGUARD_CONFIG
+      steps:
+        - vpn/install

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -73,6 +73,10 @@ steps:
       tag: << parameters.tag >>
       path: <<parameters.cwd-path-for-build>>
       extra_build_args: <<parameters.extra_build_args>>
+  - when:
+      condition: $WIREGUARD_CONFIG
+      steps:
+        - vpn/connect
   - gcr/push-image:
       registry-url: <<parameters.registry-url>>
       google-project-id: <<parameters.google-project-id>>


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Clusters with ip restrictions can not use the orb out of the box
<!---
  why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
If `WIREGUARD_CONFIG` is present it creates a vpn connection before deploying to cluster
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
