### PR TITLE
feat(jobs): split publish-and-rollout-image job

### DIFF
--- a/src/jobs/publish-image.yml
+++ b/src/jobs/publish-image.yml
@@ -1,26 +1,7 @@
-description: "Update cluster with new Docker image."
+description: "Build and publish Docker image."
 docker:
   - image: google/cloud-sdk:377.0.0
-circleci_ip_ranges: true
 parameters:
-  cluster:
-    description: "The Kubernetes cluster name."
-    type: string
-  deployment:
-    description: "The Kubernetes deployment name."
-    type: string
-    default: ""
-  namespace:
-    description: "The Kubernetes namespace name."
-    type: string
-    default: "default"
-  container:
-    description: "The Kubernetes container name."
-    type: string
-  gcloud-service-key:
-    description: The gcloud service key
-    type: env_var_name
-    default: GCLOUD_SERVICE_KEY
   google-project-id:
     description: The Google project ID to connect with via the gcloud CLI
     type: env_var_name
@@ -40,10 +21,6 @@ parameters:
     description: A docker image tag
     type: string
     default: "latest"
-  stable-tag:
-    description: A docker image tag added after a successful image rollout
-    type: string
-    default: "$CIRCLE_BRANCH.stable"
   cwd-path-for-build:
     description: The relative path from where docker will start the build of the image
     type: string
@@ -83,26 +60,3 @@ steps:
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
-  - get-cluster-credentials:
-      cluster: "<<parameters.cluster>>"
-  - rollout-image:
-      deployment: "<<parameters.deployment>>"
-      namespace: "<<parameters.namespace>>"
-      container: "<<parameters.container>>"
-      image: "<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>>"
-  - gcr/tag-image:
-      registry-url: <<parameters.registry-url>>
-      google-project-id: <<parameters.google-project-id>>
-      image: <<parameters.image>>
-      source-tag: <<parameters.tag>>
-      target-tag: "<<parameters.stable-tag>>"
-  - notify-datadog:
-      image: "<<parameters.image>>:<<parameters.tag>>"
-  - notify-sentry:
-      version: "$CIRCLE_PROJECT_REPONAME:<<parameters.tag>>"
-  - notify-slack:
-      text: "Deployed *<<parameters.image>>:<<parameters.tag>>*
-
-        <$CIRCLE_BUILD_URL|Build> by: <https://github.com/$CIRCLE_USERNAME|$CIRCLE_USERNAME>
-
-        message: $GIT_COMMIT_DESC"

--- a/src/jobs/rollout-image.yml
+++ b/src/jobs/rollout-image.yml
@@ -1,0 +1,74 @@
+description: "Update cluster with new Docker image."
+docker:
+  - image: google/cloud-sdk:377.0.0
+circleci_ip_ranges: true
+parameters:
+  cluster:
+    description: The Kubernetes cluster name.
+    type: string
+  container:
+    description: The Kubernetes container name.
+    type: string
+  deployment:
+    default: ""
+    description: The Kubernetes deployment name.
+    type: string
+  google-compute-zone:
+    default: GOOGLE_COMPUTE_ZONE
+    description: The Google compute zone to connect with via the gcloud CLI
+    type: env_var_name
+  google-project-id:
+    default: GOOGLE_PROJECT_ID
+    description: The Google project ID to connect with via the gcloud CLI
+    type: env_var_name
+  image:
+    description: A name for your docker image
+    type: string
+  namespace:
+    default: default
+    description: The Kubernetes namespace name.
+    type: string
+  registry-url:
+    default: gcr.io
+    description: The GCR registry URL from ['', us, eu, asia].gcr.io
+    type: string
+  stable-tag:
+    default: $CIRCLE_BRANCH.stable
+    description: A docker image tag added after a successful image rollout
+    type: string
+  tag:
+    default: latest
+    description: A docker image tag
+    type: string
+steps:
+  - add_ssh_keys
+  - checkout-submodule
+  - attach_workspace:
+      at: ./
+  - gcr/gcr-auth:
+      google-project-id: <<parameters.google-project-id>>
+      google-compute-zone: <<parameters.google-compute-zone>>
+  - install
+  - get-cluster-credentials:
+      cluster: "<<parameters.cluster>>"
+  - rollout-image:
+      deployment: "<<parameters.deployment>>"
+      namespace: "<<parameters.namespace>>"
+      container: "<<parameters.container>>"
+      image: "<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>>"
+  - gcr/tag-image:
+      registry-url: <<parameters.registry-url>>
+      google-project-id: <<parameters.google-project-id>>
+      image: <<parameters.image>>
+      source-tag: <<parameters.tag>>
+      target-tag: "<<parameters.stable-tag>>"
+  - notify-datadog:
+      image: "<<parameters.image>>:<<parameters.tag>>"
+  - notify-sentry:
+      version: "$CIRCLE_PROJECT_REPONAME:<<parameters.tag>>"
+  - notify-slack:
+      text: "Deployed *<<parameters.image>>:<<parameters.tag>>*
+
+        <$CIRCLE_BUILD_URL|Build> by: <https://github.com/$CIRCLE_USERNAME|$CIRCLE_USERNAME>
+
+        message: $GIT_COMMIT_DESC"


### PR DESCRIPTION
## What does this change?
Splits the `publish-and-rollout-image` job into two separate jobs, one for building/publishing to gcp, the other for rolling out

## What is the context and motivation behind this?
Circle CI is disabling the use of IP ranges with remote docker executors (taking effect on **12th Aug**).
https://discuss.circleci.com/t/fyi-jobs-that-use-the-ip-ranges-feature-and-remote-docker-will-begin-to-fast-fail-this-week/44639/7

The old job uses both of these features, and will fail once this is disabled. The new jobs only need one feature each (remote docker for the build & publish step, IP ranges for connecting to the cluster during rollouts)

### Tested

I've tested deployments to staging on a few repos. We'll have to wait until CircleCI switches off this feature to be sure

## Links

Related Jira ticket: https://hisnob.atlassian.net/browse/HSNB-1623
